### PR TITLE
Break after effect found

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ class Manager {
                         priceindex = itemData.effects[_effect];
                         if (quality === "Strange") quality = "Strange Unusual";
                         else quality = "Unusual";
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Add a break after an effect is found, to prevent matching multiple effect names in single item.
Example broken item: `Massed Flies Smoking Skid Lid`